### PR TITLE
Update download link in Compiling instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Download archive into temp directory
 ```sh
 # mkdir -p /tmp/t4u
 # cd /tmp/t4u
-# wget https://github.com/abperiasamy/rtl8812AU_8821AU_linux/archive/master.zip
+# wget https://github.com/omegacoleman/rtl8812AU_8821AU_linux/archive/refs/heads/kernel-5.10.zip
 ```
 
 Unzip


### PR DESCRIPTION
Updated the Compiling instruction for Ubuntu and Debian with the download link from the branch containing all commits needed for building against 5.10+